### PR TITLE
Added Lambdas and ECS access to environment variables 

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -92,7 +92,7 @@ resource "aws_security_group" "c13_ecs_service_sg" {
 		from_port   = 8501
 		to_port     = 8501
 		protocol    = "tcp"
-		cidr_blocks = ["0.0.0.0/0"]  # Allows access from anywhere
+		cidr_blocks = ["0.0.0.0/0"]  # Allows access from anywhere, for ease in this project.
   }
 
   egress {
@@ -195,7 +195,7 @@ resource "aws_lambda_function" "lambda_functions" {
 	role          = aws_iam_role.lambda_exec_role.arn
 	package_type  = "Image"
 	image_uri     = each.value.image_uri
-	timeout       = 900
+	timeout       = 900 # Set the to maximum time of 900 seconds (15 minutes).
 	memory_size   = 512
 
 # All Lamda fucntions will have access to these tf.vars env variables at run time.
@@ -527,6 +527,8 @@ resource "aws_ecs_task_definition" "c13_starwatch_task" {
 			}
 		]
 
+			# The environement the ECS service runs in will have access
+			# to all environment variables in local.common_env_vars.
 			environment = [
 			for key, value in local.common_env_vars : {
 			name  = key

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -33,9 +33,9 @@ data "aws_ecs_cluster" "c13-cluster" {
 }
 
 # This locals defined the environment variables needed by our
-# Lambdas and ECS dashboard service. A sensitive tag is sometimes
-# applied to ensure the values themselves don't appear in terminal 
-# logs out ouputs of any kind. Truly secure!
+# Lambdas and ECS dashboard service. In the variables.tf file 
+# a sensitive tag is sometimes applied to ensure the values themselves
+# don't appear in terminal logs, or ouputs of any kind. Truly secure!
 locals {
   common_env_vars = {
     # Database connection variables
@@ -519,6 +519,8 @@ resource "aws_ecs_task_definition" "c13_starwatch_task" {
 		essential = true
 		portMappings = [
 			{
+			# containerPort and hostPost are set to the same default Streamlit port number,
+			# as for simplicity, the container and the dhasboard can both listen to requests to the same port.
 			containerPort = 8501
 			hostPort      = 8501
 			protocol      = "tcp"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -14,6 +14,10 @@ variable "AWS_SECRET_KEY" {
   
 }
 
+variable "DB_HOST" {
+  type = string
+  
+}
 
 
 variable "DB_NAME" {
@@ -26,13 +30,16 @@ variable "DB_USER" {
   
 }
 
+
 variable "DB_PASSWORD" {
   type = string
+  sensitive   = true
   
 }
 
 variable "VPC_ID" {
     type = string
+    sensitive   = true
 }
 
 
@@ -73,4 +80,25 @@ variable "DASHBOARD_IMAGE_URI" {
 
 variable "CLUSTER_NAME" {
     type = string
+}
+
+
+variable "NASA_API_KEY" {
+  type = string
+  sensitive   = true
+  
+}
+
+
+
+variable "ASTRONOMY_KEY_ID" {
+  type = string
+  sensitive   = true
+  
+}
+
+variable "ASTRONOMY_SECRET" {
+  type = string
+  sensitive   = true
+  
 }


### PR DESCRIPTION
All compute related to all pipelines for the StarWatch project now have access to environment variables at run time. Providing access to these variables within the container itself is unsafe, as a container's contents can be inspected, potentially exposing sensitive information. 

To avoid this, the necessary environment variables have been baked into the Terraform build itself, meaning they are injected into Lambdas running images from ECR at runtime. As the terraform.tfvars is not pushed to GitHub and remain on local machines, environment variables are kept safe when used in containers.


This closes: #150 