### PR TITLE
Make failing test readout more clear.

### DIFF
--- a/.github/workflows/py_test.yml
+++ b/.github/workflows/py_test.yml
@@ -33,6 +33,7 @@ jobs:
       run: pytest --cov=. > coverage_report.txt
 
     - name: "Upload coverage text report"
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: coverage-txt-report


### PR DESCRIPTION
This PR attempts to ensure that the "Upload coverage text report" stage of the testing action runs even if the tests themselves fail.

This should make it easier to debug failing actions.